### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "firebase": "^5.4.1",
     "jquery": "^3.3.1",
     "ng2-img-cropper": "^0.9.0",
-    "npm": "^6.9.0",
     "popper.js": "^1.14.4",
     "rxjs": "^6.0.0",
     "zone.js": "~0.8.26"


### PR DESCRIPTION

Hello jeevahasan!

It seems like you have npm as one of your (dev-) dependency in angularsampleform.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
